### PR TITLE
Fix #1 support quoted charsets / returning 40 status codes for invalid charsets

### DIFF
--- a/Helpers/MimeHelper.cs
+++ b/Helpers/MimeHelper.cs
@@ -2,6 +2,9 @@ using System.Net.Http.Headers;
 
 namespace Stargate.Helpers;
 
+/// <summary>
+/// Centralized place for parsing/normalizing Mime types and charsets
+/// </summary>
 public static class MimeHelper
 {
     public static string? NormalizeCharset(MediaTypeHeaderValue? contentType)

--- a/Helpers/MimeHelper.cs
+++ b/Helpers/MimeHelper.cs
@@ -1,0 +1,15 @@
+using System.Net.Http.Headers;
+
+namespace Stargate.Helpers;
+
+public static class MimeHelper
+{
+    public static string? NormalizeCharset(MediaTypeHeaderValue? contentType)
+    {
+        string charset = contentType?.CharSet ?? "";
+        // Trim whitespace and quotes some servers add around charset, which makes .NET's Encoding.GetEncoding throw an exception
+        charset = charset.Trim().Trim('"', '\'');
+        
+        return !string.IsNullOrWhiteSpace(charset) ? charset : null; 
+    }
+}

--- a/SourceResponse.cs
+++ b/SourceResponse.cs
@@ -15,7 +15,7 @@ public class SourceResponse
 	public string Meta { get; set; } = "";
 
 	/// <summary>
-	///     The content type of the s
+	///     The original parsed Content-Type header (if present) 
 	/// </summary>
 	public MediaTypeHeaderValue SourceContentType { get; set; }
 


### PR DESCRIPTION
Fixed 2 different things found with #1 :

* If a charset is provided that is unsupported/invalid, stargate should catch it early enough to return a 40
* quoted charset values are perfectly valid for HTTP Content-Type headers, but needed to be normalized before being used by .NET's Encoding methods